### PR TITLE
JSX support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import {
   styleModule,
 } from "snabbdom";
 
-export { h } from "snabbdom";
+export { h, jsx } from "snabbdom";
 
 let snabbdomPatch = init([
   attributesModule,


### PR DESCRIPTION
snabbdom supports JSX as an alternative to its own syntax. This MR passes through support to flyps-dom-snabbdom.